### PR TITLE
Separate storage and configuration, accelerate image construction

### DIFF
--- a/Dockerfile.npc
+++ b/Dockerfile.npc
@@ -1,5 +1,5 @@
 FROM golang:1.15 as builder
-ARG GOPROXY=direct
+ARG GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /go/src/ehang.io/nps
 COPY . .
 RUN go get -d -v ./... 
@@ -7,5 +7,6 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s -extldflags -static" ./cmd/npc/npc.go
 
 FROM scratch
 COPY --from=builder /go/src/ehang.io/nps/npc /
-VOLUME /conf
-ENTRYPOINT ["/npc"]
+COPY --from=builder /go/src/ehang.io/nps/conf /conf
+VOLUME /db
+CMD ["/npc"]

--- a/Dockerfile.nps
+++ b/Dockerfile.nps
@@ -1,12 +1,13 @@
 FROM golang:1.15 as builder
-ARG GOPROXY=direct
+ARG GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /go/src/ehang.io/nps
 COPY . .
 RUN go get -d -v ./... 
 RUN CGO_ENABLED=0 go build -ldflags="-w -s -extldflags -static" ./cmd/nps/nps.go
 
 FROM scratch
+COPY --from=builder /go/src/ehang.io/nps/conf /conf
 COPY --from=builder /go/src/ehang.io/nps/nps /
 COPY --from=builder /go/src/ehang.io/nps/web /web
-VOLUME /conf
+VOLUME /db
 CMD ["/nps"]

--- a/build.assets.sh
+++ b/build.assets.sh
@@ -80,77 +80,77 @@ tar -czvf darwin_amd64_client.tar.gz npc conf/npc.conf conf/multi_account.conf
 
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_386_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_386_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_arm_v5_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm_v5_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_arm_v6_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm_v6_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_arm_v7_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm_v7_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_arm64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=freebsd GOARCH=arm go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf freebsd_arm_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf freebsd_arm_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=freebsd GOARCH=386 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf freebsd_386_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf freebsd_386_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf freebsd_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf freebsd_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mips go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_mips_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mips_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mips64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_mips64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mips64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mips64le go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_mips64le_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mips64le_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mipsle go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf linux_mipsle_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mipsle_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf darwin_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf darwin_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf windows_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
+tar -czvf windows_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
 
 
 CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
 
-tar -czvf windows_386_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
+tar -czvf windows_386_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe

--- a/build.sh
+++ b/build.sh
@@ -81,71 +81,71 @@ tar -czvf darwin_arm64_client.tar.gz npc conf/npc.conf conf/multi_account.conf
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_386_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_386_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_arm_v5_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm_v5_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_arm_v6_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm_v6_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_arm_v7_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm_v7_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_arm64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_arm64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=freebsd GOARCH=arm go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf freebsd_arm_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf freebsd_arm_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=freebsd GOARCH=386 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf freebsd_386_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf freebsd_386_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf freebsd_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf freebsd_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mips go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_mips_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mips_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mips64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_mips64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mips64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mips64le go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_mips64le_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mips64le_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=linux GOARCH=mipsle go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf linux_mipsle_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf linux_mipsle_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf darwin_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf darwin_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf darwin_arm64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps
+tar -czvf darwin_arm64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps
 
 
 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf windows_amd64_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
+tar -czvf windows_amd64_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
 
 
 CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "-s -w -extldflags -static -extldflags -static" ./cmd/nps/nps.go
-tar -czvf windows_386_server.tar.gz conf/nps.conf conf/tasks.json conf/clients.json conf/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
+tar -czvf windows_386_server.tar.gz conf/nps.conf db/tasks.json db/clients.json db/hosts.json conf/server.key  conf/server.pem web/views web/static nps.exe
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/lib/file/file.go
+++ b/lib/file/file.go
@@ -9,18 +9,45 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-
+	"fmt"
 	"ehang.io/nps/lib/common"
 	"ehang.io/nps/lib/rate"
 )
 
 func NewJsonDb(runPath string) *JsonDb {
+	TaskFile := filepath.Join(runPath, "db", "tasks.json")
+	HostFile := filepath.Join(runPath, "db", "hosts.json")
+	ClientFile := filepath.Join(runPath, "db", "clients.json")
+	exist, _ := PathExists(TaskFile)
+	fmt.Println(exist)
+	if !exist{
+		_, _ = os.Create(TaskFile)
+		_, _ = os.Create(HostFile)
+		_, _ = os.Create(ClientFile)
+	}
+	exist, _ = PathExists(TaskFile)
+	fmt.Println(exist)
 	return &JsonDb{
 		RunPath:        runPath,
-		TaskFilePath:   filepath.Join(runPath, "conf", "tasks.json"),
-		HostFilePath:   filepath.Join(runPath, "conf", "hosts.json"),
-		ClientFilePath: filepath.Join(runPath, "conf", "clients.json"),
+		TaskFilePath:   TaskFile,
+		HostFilePath:   HostFile,
+		ClientFilePath: ClientFile,
 	}
+}
+
+func PathExists(path string) (bool, error) {
+    _, err := os.Stat(path)
+    if err == nil {
+        return true, nil
+    }
+    if os.IsNotExist(err) {
+        return false, nil
+    }
+    return false, err
+}
+
+func CreateJsonDb(path string){
+
 }
 
 type JsonDb struct {

--- a/lib/file/file.go
+++ b/lib/file/file.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"fmt"
 	"ehang.io/nps/lib/common"
 	"ehang.io/nps/lib/rate"
 )
@@ -19,14 +18,11 @@ func NewJsonDb(runPath string) *JsonDb {
 	HostFile := filepath.Join(runPath, "db", "hosts.json")
 	ClientFile := filepath.Join(runPath, "db", "clients.json")
 	exist, _ := PathExists(TaskFile)
-	fmt.Println(exist)
 	if !exist{
 		_, _ = os.Create(TaskFile)
 		_, _ = os.Create(HostFile)
 		_, _ = os.Create(ClientFile)
 	}
-	exist, _ = PathExists(TaskFile)
-	fmt.Println(exist)
 	return &JsonDb{
 		RunPath:        runPath,
 		TaskFilePath:   TaskFile,


### PR DESCRIPTION
When modifying a build, use the Alibaba acceleration address; Modify file Go enables it to store the data in the "/db" directory, separating the configuration from the data storage, so as to adapt to the later transfer of the Docker to the K8S application, and better support the help package for use.