### PR TITLE
Update socks5.go

### DIFF
--- a/server/proxy/socks5.go
+++ b/server/proxy/socks5.go
@@ -344,6 +344,9 @@ func (s *Sock5ModeServer) Auth(c net.Conn) error {
 	if s.task.MultiAccount != nil {
 		// enable multi user auth
 		U = string(user)
+		if len(U) == 0 {
+		        return errors.New("验证不通过")
+		}
 		var ok bool
 		P, ok = s.task.MultiAccount.AccountMap[U]
 		if !ok {


### PR DESCRIPTION
修复：开启socks5多用户，个别sockes5客户端使用空用户名或空密码可以连接成功