### PR TITLE
修复域名解析https下不显示404页面问题

### DIFF
--- a/server/proxy/https.go
+++ b/server/proxy/https.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"sync"
 
 	"ehang.io/nps/lib/cache"
@@ -34,6 +35,10 @@ func NewHttpsServer(l net.Listener, bridge NetBridge, useCache bool, cacheLen in
 
 //start https server
 func (https *HttpsServer) Start() error {
+	var err error
+	if https.errorContent, err = common.ReadAllFromFile(filepath.Join(common.GetRunPath(), "web", "static", "page", "error.html")); err != nil {
+		https.errorContent = []byte("nps 404")
+	}
 	if b, err := beego.AppConfig.Bool("https_just_proxy"); err == nil && b {
 		conn.Accept(https.listener, func(c net.Conn) {
 			https.handleHttps(c)


### PR DESCRIPTION
http域名解析如遇到超过流量或者文件不存在会显示404 错误页面，但是https并不显示这个页面。
以上pull request内容修复这个问题。