### PR TITLE
自动生成端口号支持 allow_ports 参数

### DIFF
--- a/server/tool/utils.go
+++ b/server/tool/utils.go
@@ -52,11 +52,21 @@ func TestServerPort(p int, m string) (b bool) {
 }
 
 func GenerateServerPort(m string) int {
+	allowPortsLen := len(ports)
+	allowPortsNumber := 0
 	for {
-		//生成随机数 1024 - 65535
-		serverPort := rand.Intn(65535)
-		if serverPort < 1024 {
-			serverPort = 1024
+		var serverPort int
+
+		if allowPortsLen > 10 && allowPortsNumber < 3 {
+			rand.Seed(time.Now().UnixNano())
+			serverPort = ports[rand.Intn(allowPortsLen)]
+			allowPortsNumber++
+		} else {
+			//生成随机数 1024 - 65535
+			serverPort = rand.Intn(65535)
+			if serverPort < 1024 {
+				serverPort = 1024
+			}
 		}
 
 		if TestServerPort(serverPort, m) {


### PR DESCRIPTION
当 allow_ports 配置开启并且可用端口大于10时 生成基于此配置文件的端口