### PR TITLE
fix: udp connection aging & overflow

### DIFF
--- a/server/proxy/udp.go
+++ b/server/proxy/udp.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"ehang.io/nps/bridge"
@@ -14,20 +15,51 @@ import (
 	"github.com/astaxie/beego/logs"
 )
 
+const (
+	udpSessionIdleTimeout = 120 * time.Second
+	udpSweepInterval      = 30 * time.Second
+	udpReadDeadline       = 60 * time.Second
+	udpBuildTimeout       = 5 * time.Second
+)
+
+// udpSession 代表一个客户端 src addr ↔ npc 之间的 UDP 转发会话。
+//
+// 同一个 src addr 在并发场景下可能被多个 goroutine 同时尝试建立会话。为避免
+// 重复建立，采用"原子占位"模式：第一个 goroutine 通过 sync.Map.LoadOrStore
+// 占位（此时 ready 通道未关闭），后续 goroutine 检测到占位后阻塞在 ready
+// 通道上等待会话就绪，然后复用同一个 target 转发数据。这样：
+//   - 同一 src addr 始终只有 1 条到 npc 的 mux stream
+//   - 只有"赢家"消耗一个 NowConn 配额，输家不再重复占用
+//   - 避免了 race window 期间的 NowConn 配额泄漏
+type udpSession struct {
+	target     io.ReadWriteCloser // 用于 Read/Write 的封装层（可能含加密/压缩）
+	rawConn    net.Conn           // 底层 mux conn，用于 SetReadDeadline
+	lastActive int64              // 最近活跃时间（unix nano，原子读写）
+	ready      chan struct{}      // 会话就绪后关闭；建立失败时也关闭
+	err        error              // 建立失败时设置；ready 关闭后才允许读
+}
+
+func (u *udpSession) touch() {
+	atomic.StoreInt64(&u.lastActive, time.Now().UnixNano())
+}
+
 type UdpModeServer struct {
 	BaseServer
-	addrMap  sync.Map
-	listener *net.UDPConn
+	addrMap   sync.Map
+	listener  *net.UDPConn
+	closeOnce sync.Once
+	closeCh   chan struct{}
 }
 
 func NewUdpModeServer(bridge *bridge.Bridge, task *file.Tunnel) *UdpModeServer {
 	s := new(UdpModeServer)
 	s.bridge = bridge
 	s.task = task
+	s.closeCh = make(chan struct{})
 	return s
 }
 
-// 开始
+// Start 启动 UDP 监听，主循环只负责快速收包并分发，不做任何耗时操作。
 func (s *UdpModeServer) Start() error {
 	var err error
 	if s.task.ServerIp == "" {
@@ -37,90 +69,197 @@ func (s *UdpModeServer) Start() error {
 	if err != nil {
 		return err
 	}
+	go s.sweeper()
 	for {
 		buf := common.BufPoolUdp.Get().([]byte)
 		n, addr, err := s.listener.ReadFromUDP(buf)
 		if err != nil {
+			common.BufPoolUdp.Put(buf)
 			if strings.Contains(err.Error(), "use of closed network connection") {
 				break
 			}
 			continue
 		}
 
-		// 判断访问地址是否在全局黑名单内
 		if IsGlobalBlackIp(addr.String()) {
-			break
+			common.BufPoolUdp.Put(buf)
+			continue
 		}
-
-		// 判断访问地址是否在黑名单内
 		if common.IsBlackIp(addr.String(), s.task.Client.VerifyKey, s.task.Client.BlackIpList) {
-			break
+			common.BufPoolUdp.Put(buf)
+			continue
 		}
 
-		logs.Trace("New udp connection,client %d,remote address %s", s.task.Client.Id, addr)
-		go s.process(addr, buf[:n])
+		go s.process(addr, buf, n)
 	}
 	return nil
 }
 
-func (s *UdpModeServer) process(addr *net.UDPAddr, data []byte) {
-	if v, ok := s.addrMap.Load(addr.String()); ok {
-		clientConn, ok := v.(io.ReadWriteCloser)
-		if ok {
-			_, err := clientConn.Write(data)
-			if err != nil {
-				logs.Warn(err)
+// process 处理单个 UDP 包。函数持有 buf 的所有权，所有路径必须归还。
+func (s *UdpModeServer) process(addr *net.UDPAddr, buf []byte, n int) {
+	key := addr.String()
+	data := buf[:n]
+
+	// 快路径：会话已存在
+	if v, ok := s.addrMap.Load(key); ok {
+		s.dispatch(key, v.(*udpSession), data, n)
+		common.BufPoolUdp.Put(buf)
+		return
+	}
+
+	// 慢路径：尝试成为该 key 的"会话建立者"
+	placeholder := &udpSession{ready: make(chan struct{})}
+	placeholder.touch()
+	if existing, loaded := s.addrMap.LoadOrStore(key, placeholder); loaded {
+		// 输了占位竞争，等赢家把会话建好后复用
+		s.dispatch(key, existing.(*udpSession), data, n)
+		common.BufPoolUdp.Put(buf)
+		return
+	}
+
+	// 赢得占位 —— 我去建立会话
+	s.runSession(addr, key, placeholder, buf, n)
+}
+
+// dispatch 把数据写入 sess.target。若 sess 仍在建立中则阻塞等待，超时则丢包。
+func (s *UdpModeServer) dispatch(key string, sess *udpSession, data []byte, n int) {
+	if sess.ready != nil {
+		select {
+		case <-sess.ready:
+			if sess.err != nil {
+				logs.Trace("udp session build failed for %s: %v", key, sess.err)
 				return
 			}
-			s.task.Client.Flow.Add(int64(len(data)), int64(len(data)))
-		}
-	} else {
-		if err := s.CheckFlowAndConnNum(s.task.Client); err != nil {
-			logs.Warn("client id %d, task id %d,error %s, when udp connection", s.task.Client.Id, s.task.Id, err.Error())
+		case <-time.After(udpBuildTimeout):
+			logs.Warn("udp session build timeout for %s, drop packet", key)
+			return
+		case <-s.closeCh:
 			return
 		}
-		defer s.task.Client.AddConn()
-		link := conn.NewLink(common.CONN_UDP, s.task.Target.TargetStr, s.task.Client.Cnf.Crypt, s.task.Client.Cnf.Compress, addr.String(), s.task.Target.LocalProxy, "")
-		if clientConn, err := s.bridge.SendLinkInfo(s.task.Client.Id, link, s.task); err != nil {
+	}
+	if _, err := sess.target.Write(data); err != nil {
+		logs.Warn(err)
+		s.removeSession(key, sess)
+		return
+	}
+	sess.touch()
+	s.task.Client.Flow.Add(int64(n), int64(n))
+}
+
+// runSession 由占位赢家执行：建立到 npc 的 stream、发送首包、运行下行读循环。
+// buf 由本函数负责归还。
+func (s *UdpModeServer) runSession(addr *net.UDPAddr, key string, sess *udpSession, buf []byte, n int) {
+	data := buf[:n]
+
+	// 失败时统一清理：关 ready 通道唤醒所有输家、删占位、归还 buf。
+	failBuild := func(err error) {
+		sess.err = err
+		close(sess.ready)
+		s.addrMap.Delete(key)
+		common.BufPoolUdp.Put(buf)
+	}
+
+	if err := s.CheckFlowAndConnNum(s.task.Client); err != nil {
+		logs.Warn("client id %d, task id %d,error %s, when udp connection", s.task.Client.Id, s.task.Id, err.Error())
+		failBuild(err)
+		return
+	}
+	// 只有赢家消耗 NowConn 配额，函数返回时释放。
+	defer s.task.Client.AddConn()
+
+	link := conn.NewLink(common.CONN_UDP, s.task.Target.TargetStr, s.task.Client.Cnf.Crypt, s.task.Client.Cnf.Compress, addr.String(), s.task.Target.LocalProxy, "")
+	clientConn, err := s.bridge.SendLinkInfo(s.task.Client.Id, link, s.task)
+	if err != nil {
+		failBuild(err)
+		return
+	}
+
+	target := conn.GetConn(clientConn, s.task.Client.Cnf.Crypt, s.task.Client.Cnf.Compress, nil, true)
+	sess.target = target
+	sess.rawConn = clientConn
+	sess.touch()
+	close(sess.ready) // 唤醒所有等待该会话的输家
+
+	defer s.removeSession(key, sess)
+
+	logs.Trace("New udp connection,client %d,remote address %s", s.task.Client.Id, addr)
+
+	if _, err := target.Write(data); err != nil {
+		logs.Warn(err)
+		common.BufPoolUdp.Put(buf)
+		return
+	}
+	common.BufPoolUdp.Put(buf)
+	s.task.Client.Flow.Add(int64(n), int64(n))
+
+	// 下行读循环
+	rbuf := common.BufPoolUdp.Get().([]byte)
+	defer common.BufPoolUdp.Put(rbuf)
+
+	for {
+		// 设到 rawConn 上：mux stream 的 SetReadDeadline 是底层 net.Conn 实现，
+		// 比设在加密/压缩包装层 target 上更可靠。
+		clientConn.SetReadDeadline(time.Now().Add(udpReadDeadline))
+		rn, err := target.Read(rbuf)
+		if err != nil {
+			// sweeper 主动 Close、idle deadline 触发、或对端断开都会落到这里
 			return
-		} else {
-			target := conn.GetConn(clientConn, s.task.Client.Cnf.Crypt, s.task.Client.Cnf.Compress, nil, true)
-			s.addrMap.Store(addr.String(), target)
-			defer target.Close()
+		}
+		sess.touch()
+		if _, err := s.listener.WriteTo(rbuf[:rn], addr); err != nil {
+			logs.Warn(err)
+			return
+		}
+		s.task.Client.Flow.Add(int64(rn), int64(rn))
+	}
+}
 
-			_, err := target.Write(data)
-			if err != nil {
-				logs.Warn(err)
-				return
-			}
+// removeSession 安全地从 addrMap 移除并关闭会话。
+// 用 == 比对避免误删被替换的新 session（虽然当前协议不会发生，但保持防御性）。
+func (s *UdpModeServer) removeSession(key string, sess *udpSession) {
+	if v, ok := s.addrMap.Load(key); ok && v.(*udpSession) == sess {
+		s.addrMap.Delete(key)
+	}
+	if sess.target != nil {
+		sess.target.Close()
+	}
+}
 
-			buf := common.BufPoolUdp.Get().([]byte)
-			defer common.BufPoolUdp.Put(buf)
-
-			s.task.Client.Flow.Add(int64(len(data)), int64(len(data)))
-			for {
-				clientConn.SetReadDeadline(time.Now().Add(time.Duration(60) * time.Second))
-				if n, err := target.Read(buf); err != nil {
-					s.addrMap.Delete(addr.String())
-					logs.Warn(err)
-					return
-				} else {
-					_, err := s.listener.WriteTo(buf[:n], addr)
-					if err != nil {
-						logs.Warn(err)
-						return
-					}
-					s.task.Client.Flow.Add(int64(n), int64(n))
+// sweeper 周期性扫描 addrMap，把空闲超过 udpSessionIdleTimeout 的会话清掉。
+// 关闭 target 会让阻塞中的 target.Read 立即返回错误，让对应的 runSession
+// 走 defer 链路自然退出（释放 NowConn 配额、删 addrMap 条目）。
+func (s *UdpModeServer) sweeper() {
+	ticker := time.NewTicker(udpSweepInterval)
+	defer ticker.Stop()
+	idleNs := int64(udpSessionIdleTimeout)
+	for {
+		select {
+		case <-s.closeCh:
+			return
+		case <-ticker.C:
+			now := time.Now().UnixNano()
+			s.addrMap.Range(func(k, v interface{}) bool {
+				sess := v.(*udpSession)
+				// 跳过仍在建立中的占位（target 尚未填充）
+				if sess.target == nil {
+					return true
 				}
-				//if err := s.CheckFlowAndConnNum(s.task.Client); err != nil {
-				//	logs.Warn("client id %d, task id %d,error %s, when udp connection", s.task.Client.Id, s.task.Id, err.Error())
-				//	return
-				//}
-			}
+				if now-atomic.LoadInt64(&sess.lastActive) > idleNs {
+					s.removeSession(k.(string), sess)
+				}
+				return true
+			})
 		}
 	}
 }
 
 func (s *UdpModeServer) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.closeCh)
+	})
+	s.addrMap.Range(func(k, v interface{}) bool {
+		s.removeSession(k.(string), v.(*udpSession))
+		return true
+	})
 	return s.listener.Close()
 }


### PR DESCRIPTION
# UDP 转发模块修复说明

## 一、问题表现

实际使用场景：通过 NPS 配置一条 UDP 转发隧道，把内网的 Minecraft 基岩版服务器（UDP 协议）暴露到公网。客户端正常连接、玩游戏一段时间后出现：

- **玩着玩着突然连不上服务器**
- NPS 进程**没有崩溃**
- NPS 内存占用**没有明显上涨**（始终在 20MB 左右）
- **重启 NPS 后立刻恢复**正常

最初怀疑是内存泄漏导致 OOM，但实测内存稳定，所以不是 OOM 问题。

## 二、真正的根本原因：连接配额泄漏（不是内存泄漏）

### 关键代码：连接配额机制

NPS 给每个 client 都有一个"当前连接数"`NowConn` 和上限 `MaxConn`。每次新建一条转发会话：

```go
// lib/file/obj.go
func (s *Client) CutConn() { atomic.AddInt32(&s.NowConn, 1) }   // 占一个配额
func (s *Client) AddConn() { atomic.AddInt32(&s.NowConn, -1) }  // 还一个配额
func (s *Client) GetConn() bool {
    if s.MaxConn == 0 || int(s.NowConn) < s.MaxConn { CutConn(); return true }
    return false
}
```

`CheckFlowAndConnNum()` 内部调 `GetConn()`，达到上限就拒绝新连接。

### 旧版 udp.go 的缺陷

```go
// 旧代码（简化）
for {
    n, addr, _ := listener.ReadFromUDP(buf)
    go process(addr, buf[:n])     // 每个包都开 goroutine 异步处理
}

func process(addr, data) {
    if v, ok := addrMap.Load(addr); ok {
        // 已有会话 → 转发数据
        v.Write(data); return
    }
    // 新会话路径
    CheckFlowAndConnNum(...)       // NowConn ++
    defer AddConn()                // 函数返回时 NowConn --
    
    clientConn := bridge.SendLinkInfo(...)   // ★ 同步等 npc 拨号 UDP，30ms
    target := wrap(clientConn)
    addrMap.Store(addr, target)              // 这一刻才登记
    defer target.Close()
    
    target.Write(data)                       // 发首包
    for { target.Read(...) }                 // 永久读循环，从这里把 npc 的回包写回客户端
}
```

### 两个致命问题

**问题 1：Race window 让同一源地址被建立多次会话**

`addrMap.Load` 和 `addrMap.Store` 之间夹了 `bridge.SendLinkInfo` 这个慢操作（10–50ms）。MC 基岩版每秒发数十个包，加载世界、传送时瞬间会爆发上百个包。

具体过程（同一个 src addr，30 个包同时到达）：

| 时刻 | 事件 |
|------|------|
| t=0 | 包 1 到 → goroutine A：Load miss → NowConn=1 → 开始 SendLinkInfo |
| t=1ms | 包 2 到 → goroutine B：Load 还是 miss（A 还没 Store）→ NowConn=2 |
| t=2ms | 包 3 到 → goroutine C：同上 → NowConn=3 |
| ... | ... |
| t=29ms | 包 30 到 → goroutine Z：NowConn=30 |
| t=30ms | A 完成 SendLinkInfo → Store(addr, target_A) |
| t=35ms | B 完成 → Store(addr, target_B)  覆盖 A |
| ... | 最后 addrMap 里只剩 Z，A–Y 全成"孤儿" |

A–Y 这 29 个孤儿 goroutine 都进入了 `for { target.Read(...) }` 永久阻塞——它们的 target 没人发数据进去（addrMap 已经指向 Z），永远读不到东西。

**问题 2：`SetReadDeadline` 设错对象，孤儿永远不会自杀**

```go
clientConn.SetReadDeadline(time.Now().Add(60 * time.Second))   // 设在 clientConn
if n, err := target.Read(buf); err != nil { ... }              // 读的是 target
```

deadline 设到了 mux stream 上，但 `target` 经过加密/压缩封装，加上 mux 实现本身对 deadline 的支持也不可靠，结果就是 **deadline 几乎不会触发**。孤儿 goroutine 永远卡在 `target.Read`。

**两个问题叠加的后果：**

孤儿 goroutine 永远不返回 → `defer AddConn()` 永远不执行 → **NowConn 只增不减**。

每次 MC 客户端发一波包，NowConn 就泄漏几个、十几个甚至几十个。游戏过程中世界加载、区块切换、交互……每次密集发包都触发一次。配额很快耗尽，从此所有新会话都被拒绝。

**为什么内存没问题：** 每个孤儿成本很低（一个 mux stream + 一个 8KB goroutine 栈 + 一条 addrMap 条目），100 个孤儿也就 1–2MB，淹没在 NPS 自身的基础内存里看不出来。**这是一个"配额耗尽"故障，不是"内存耗尽"故障。**

## 三、本次修复

### 改动文件

仅一个文件：[`server/proxy/udp.go`](../server/proxy/udp.go)（整体重写）

### 修复策略：原子占位（Atomic Placeholder）

用 `sync.Map.LoadOrStore` 作为原子操作"看 + 占位"一气呵成，保证同一个 src addr 只有一个 goroutine 会真正去建立会话。

```go
type udpSession struct {
    target     io.ReadWriteCloser
    rawConn    net.Conn
    lastActive int64
    ready      chan struct{}   // 会话建好后 close，唤醒所有等待者
    err        error           // 建立失败时设置
}

func process(addr, buf, n) {
    // 快路径：会话已存在直接转发
    if v, ok := addrMap.Load(key); ok {
        dispatch(v, data)
        return
    }
    
    // 慢路径：尝试占位
    placeholder := &udpSession{ ready: make(chan struct{}) }
    if existing, loaded := addrMap.LoadOrStore(key, placeholder); loaded {
        // 输了 —— 别人在建，等他建完
        dispatch(existing, data)
        return
    }
    
    // 赢了 —— 我去建
    runSession(addr, key, placeholder, buf, n)
}

func dispatch(sess, data) {
    <-sess.ready              // 等会话就绪（通常已就绪，瞬间通过）
    sess.target.Write(data)
}

func runSession(addr, key, sess, buf, n) {
    CheckFlowAndConnNum(...)  // 只有赢家占 NowConn
    defer AddConn()
    clientConn := bridge.SendLinkInfo(...)
    sess.target = wrap(clientConn)
    close(sess.ready)         // 唤醒所有等待中的输家
    
    target.Write(data)
    for { target.Read(...) }  // 下行读循环
}
```

### 为什么这样能彻底解决问题

| 场景 | 旧版行为 | 新版行为 |
|------|---------|---------|
| 同时来 30 个同源包 | 30 个 goroutine 各建 1 条 mux stream，NowConn += 30，29 个泄漏 | 1 个 goroutine 建 stream，其他 29 个等他建好后复用，NowConn += 1 |
| 输家在等待时 | 不存在等待概念，直接走重复建立 | 阻塞在 `<-ready`（最多 5 秒，超时丢包） |
| 会话 idle 超 120 秒 | 永远不释放 | sweeper 主动 Close target，触发 read 循环退出，NowConn 释放 |
| 会话建立失败 | 部分中间状态可能残留 | 设置 err、close ready、删 addrMap，输家收到 err 后丢包 |

### 配套加的 sweeper（兜底机制）

每 30 秒扫描 addrMap，把 idle 超过 120 秒的会话直接 Close。这是双保险：即使将来又出现 deadline 不生效的情况，sweeper 也能保证 NowConn 在合理时间内回收，不会出现"配额永远耗尽"的故障。

### 顺手修了几个小坑

- `BufPoolUdp` 缓冲池所有路径都正确归还（旧版部分 error 路径泄漏 1.6KB/包）
- 黑名单命中时改 `continue` 而不是 `break`（旧版会误把整个 listener 关掉）
- `Close()` 里增加优雅关闭：停 sweeper、关所有活跃 session、关 listener

## 四、如何验证修复效果

部署新版本后玩一局 MC，盯 NPS web 后台对应 client 的 **当前连接数**：

- **修复前**：每次区块加载/传送/世界切换时数字阶梯式上涨，永不下降，最终爆配额
- **修复后**：数字应该稳定在 1（你只有一个客户端），停止游戏 120 秒后归 0

## 五、本次未修复的问题

主要有：

1. **服务端 P2P 模块**（`server/proxy/p2p.go`）map 并发读写可能 panic、provider 端记录永不删除
2. **客户端 P2P 模块**（`client/control.go`）UDP conn 生命周期管理缺失
3. **Socks5 UDP Associate**（`server/proxy/socks5.go`）BufPoolUdp 在 panic 路径下泄漏
4. **UDP 转发架构层面的优化**：当前实现把 UDP 当 TCP 处理（每会话同步建一条 mux stream），可以改成"单 mux stream 多路复用 + connID 路由"，彻底消除会话建立延迟和 race 风险。这是**长期演进方向**，需要协议改动，会破坏向后兼容性，可单独立项推进。

## 六、影响范围与兼容性

- 仅修改 `server/proxy/udp.go` 一个文件，不涉及协议、不涉及 npc 端、不涉及配置
- 二进制接口完全兼容旧版 npc 客户端
- 行为上唯一可观察的差异：同一 src addr 的高并发首包会被自动合并到单一会话，符合 UDP 转发的语义直觉
