### PR TITLE
fix: 保留 TCP Basic 认证探测期间已读取的数据

### DIFF
--- a/lib/conn/conn.go
+++ b/lib/conn/conn.go
@@ -39,10 +39,10 @@ func (s *Conn) readRequest(buf []byte) (n int, err error) {
 	var rd int
 	for {
 		rd, err = s.Read(buf[n:])
+		n += rd
 		if err != nil {
 			return
 		}
-		n += rd
 		if n < 4 {
 			continue
 		}
@@ -61,10 +61,12 @@ func (s *Conn) readRequest(buf []byte) (n int, err error) {
 func (s *Conn) GetHost() (method, address string, rb []byte, err error, r *http.Request) {
 	var b [32 * 1024]byte
 	var n int
-	if n, err = s.readRequest(b[:]); err != nil {
+	if n, err = s.readRequest(b[:]); n > 0 {
+		rb = b[:n]
+	}
+	if err != nil {
 		return
 	}
-	rb = b[:n]
 	r, err = http.ReadRequest(bufio.NewReader(bytes.NewReader(rb)))
 	if err != nil {
 		return

--- a/lib/conn/conn_test.go
+++ b/lib/conn/conn_test.go
@@ -1,0 +1,77 @@
+package conn
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+type bytesThenErrConn struct {
+	net.Conn
+	payload []byte
+	err     error
+	read    bool
+}
+
+func (c *bytesThenErrConn) Read(b []byte) (int, error) {
+	if c.read {
+		return 0, c.err
+	}
+	c.read = true
+	return copy(b, c.payload), c.err
+}
+
+func TestGetHostReturnsBufferedBytesOnReadError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	payload := []byte("SSH-2.0-OpenSSH_9.0\r\n")
+	if err := serverConn.SetReadDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		rb  []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, _, rb, err, _ := NewConn(serverConn).GetHost()
+		done <- result{rb: rb, err: err}
+	}()
+
+	if _, err := clientConn.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-done:
+		if got.err == nil {
+			t.Fatal("expected GetHost to fail for non-HTTP payload")
+		}
+		if !bytes.Equal(got.rb, payload) {
+			t.Fatalf("expected buffered payload %q, got %q", payload, got.rb)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GetHost did not return after read deadline")
+	}
+}
+
+func TestGetHostReturnsBufferedBytesWhenReadReturnsBytesAndError(t *testing.T) {
+	payload := []byte("SSH-2.0-OpenSSH_9.0\r\n")
+	c := &bytesThenErrConn{
+		payload: payload,
+		err:     io.ErrUnexpectedEOF,
+	}
+
+	_, _, rb, err, _ := NewConn(c).GetHost()
+	if err == nil {
+		t.Fatal("expected GetHost to fail for non-HTTP payload")
+	}
+	if !bytes.Equal(rb, payload) {
+		t.Fatalf("expected buffered payload %q, got %q", payload, rb)
+	}
+}

--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -122,6 +122,10 @@ func ProcessTunnel(c *conn.Conn, s *TunnelModeServer) error {
 			return s.DealClient(c, s.task.Client, targetAddr, rb, common.CONN_TCP,
 				nil, s.task.Client.Flow, s.task.Target.LocalProxy, s.task)
 		}
+		if len(rb) > 0 {
+			return s.DealClient(c, s.task.Client, targetAddr, rb, common.CONN_TCP,
+				nil, s.task.Client.Flow, s.task.Target.LocalProxy, s.task)
+		}
 	}
 
 	return s.DealClient(c, s.task.Client, targetAddr, nil, common.CONN_TCP, nil, s.task.Client.Flow, s.task.Target.LocalProxy, s.task)

--- a/server/proxy/tcp_test.go
+++ b/server/proxy/tcp_test.go
@@ -1,0 +1,94 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ehang.io/nps/lib/common"
+	"ehang.io/nps/lib/conn"
+	"ehang.io/nps/lib/file"
+)
+
+type tunnelTestBridge struct {
+	target net.Conn
+}
+
+func (b *tunnelTestBridge) SendLinkInfo(clientId int, link *conn.Link, t *file.Tunnel) (net.Conn, error) {
+	return b.target, nil
+}
+
+func TestProcessTunnelForwardsBufferedBytesWhenAuthProbeFails(t *testing.T) {
+	confPath := t.TempDir()
+	confDir := filepath.Join(confPath, "conf")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"clients.json", "tasks.json", "hosts.json"} {
+		if err := os.WriteFile(filepath.Join(confDir, name), nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldConfPath := common.ConfPath
+	common.ConfPath = confPath
+	t.Cleanup(func() {
+		common.ConfPath = oldConfPath
+	})
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	targetClient, targetServer := net.Pipe()
+	defer targetClient.Close()
+	defer targetServer.Close()
+
+	client := file.NewClient("test", true, true)
+	client.Id = 1
+	client.Cnf.U = "user"
+	client.Cnf.P = "pass"
+	task := &file.Tunnel{
+		Id:     1,
+		Client: client,
+		Target: &file.Target{
+			TargetStr: "127.0.0.1:22",
+		},
+	}
+	server := NewTunnelModeServer(ProcessTunnel, &tunnelTestBridge{target: targetServer}, task)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ProcessTunnel(conn.NewConn(serverConn), server)
+	}()
+
+	payload := []byte("SSH-2.0-OpenSSH_9.0\r\n")
+	if _, err := clientConn.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := targetClient.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(targetClient, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("expected forwarded payload %q, got %q", payload, got)
+	}
+
+	clientConn.Close()
+	targetClient.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ProcessTunnel did not exit after connections closed")
+	}
+}


### PR DESCRIPTION
## 背景

这是 #306 引入 TCP 隧道 Basic 认证后的一个后续修复。

当前 TCP 隧道配置 Basic 用户名密码后，`ProcessTunnel` 会先调用 `GetHost()`，尝试把连接首包按 HTTP 请求解析，用于检查 Basic Auth。

对于 SSH 等非 HTTP TCP 协议，探测过程可能已经读取了部分原始数据，但由于这些数据不是完整 HTTP 请求，最终会解析失败或超时。

修复前，`GetHost()` 失败后这些已经读取的数据没有继续转发给后端，导致 raw TCP 协议流被破坏。例如 SSH 转发可能出现 packet corrupt / MAC error 一类错误。

## 修改内容

- `readRequest()` 在 `Read()` 同时返回 `n > 0` 和 `err` 时，先保留已读取字节，再返回错误。
- `GetHost()` 在读取或 HTTP 解析失败时，如果已经读到数据，会把这些数据通过 `rb` 返回。
- `ProcessTunnel()` 在 TCP Basic 认证探测失败但 `rb` 非空时，把 `rb` 继续交给 `DealClient()` 转发。
- 增加测试覆盖：
  - `GetHost()` 在读超时时保留已读取数据。
  - `GetHost()` 在 `Read()` 同时返回数据和错误时保留数据。
  - `ProcessTunnel()` 在非 HTTP 首包探测失败后，仍会通过 `DealClient()` 转发已读取数据。

## 说明

这个 PR 只修复 TCP Basic 认证探测导致 raw TCP 首包被丢弃的问题。

它不改变现有 TCP Basic 认证语义，也不尝试让 HTTP Basic 认证适用于任意 TCP 协议。

## 测试

```bash
go test ./lib/conn ./server/proxy -vet=off
```

说明：当前直接运行 `go test ./server/proxy` 会被一个无关的既有 vet 问题阻塞：

```text
server/proxy/socks5.go:203:18: conversion from uint16 to string yields a string of one rune, not a string of digits
```
