### PR TITLE
修复 README 中 Star History 图表失效问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npc -server=ip:8024 -vkey=vkey1,vkey2                    # 多隧道
 
 ## 📈 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yisier/nps&type=Date)](https://star-history.com/#yisier/nps&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yisier/nps&type=Date)](https://star-history.dera.page/#yisier/nps&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标数据接口限制已经无法正常显示，需要修复。本 PR 将图表切换到可正常工作的数据源，使 Star History 图表恢复可用，感谢支持。